### PR TITLE
Add Go scrcpy client skeleton

### DIFF
--- a/goapp/adb/device.go
+++ b/goapp/adb/device.go
@@ -1,0 +1,44 @@
+package adb
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/zach-klippenstein/goadb"
+)
+
+// Device wraps an adb Device and provides helper methods
+// to start the scrcpy server on the Android device.
+type Device struct {
+	adb    *adb.Adb
+	device *adb.Device
+}
+
+// NewDevice connects to adb and returns a Device for the given serial.
+func NewDevice(serial string) (*Device, error) {
+	a, err := adb.NewWithConfig(adb.ServerConfig{PathToAdb: "adb"})
+	if err != nil {
+		return nil, fmt.Errorf("create adb client: %w", err)
+	}
+	d := a.Device(adb.DeviceWithSerial(serial))
+	return &Device{adb: a, device: d}, nil
+}
+
+// PushServer pushes scrcpy-server.jar to the device temporary directory.
+func (d *Device) PushServer(localPath string) error {
+	remotePath := "/data/local/tmp/scrcpy-server.jar"
+	return d.device.PushFile(localPath, remotePath)
+}
+
+// StartServer starts the scrcpy server using adb shell.
+func (d *Device) StartServer() (io.ReadCloser, error) {
+	// The server outputs the video stream on stdout, so we use StartShell.
+	// The command is simplified for demonstration purposes.
+	cmd := "CLASSPATH=/data/local/tmp/scrcpy-server.jar app_process / com.genymobile.scrcpy.Server 1.25"
+	return d.device.RunCommandWithByteOutput(cmd)
+}
+
+// Forward establishes a port forward from local to the scrcpy tunnel.
+func (d *Device) Forward(local string) error {
+	return d.adb.Forward(local, "localabstract:scrcpy")
+}

--- a/goapp/go.mod
+++ b/goapp/go.mod
@@ -1,0 +1,11 @@
+module github.com/yourname/scrcpy-go
+
+go 1.20
+
+require (
+    github.com/veandco/go-sdl2 v0.5.0
+    github.com/zach-klippenstein/goadb v0.0.0-20190708045414-0c5a9476c072
+    github.com/giorgisio/goav v0.0.0-20190406074633-da1bdd5a0d3e
+    github.com/go-vgo/robotgo v0.100.5
+)
+

--- a/goapp/input/handler.go
+++ b/goapp/input/handler.go
@@ -1,0 +1,36 @@
+package input
+
+import (
+	"github.com/go-vgo/robotgo"
+	"github.com/veandco/go-sdl2/sdl"
+)
+
+// Event represents a simplified control event that will be encoded
+// and sent to the scrcpy server.
+type Event struct {
+	Type   string
+	Key    sdl.Keycode
+	Button uint8
+	X, Y   int32
+}
+
+// Capture polls SDL for keyboard/mouse events and converts them to Event.
+func Capture() []Event {
+	var events []Event
+	for e := sdl.PollEvent(); e != nil; e = sdl.PollEvent() {
+		switch ev := e.(type) {
+		case *sdl.KeyboardEvent:
+			if ev.Type == sdl.KEYDOWN || ev.Type == sdl.KEYUP {
+				events = append(events, Event{Type: "key", Key: ev.Keysym.Sym})
+			}
+		case *sdl.MouseButtonEvent:
+			events = append(events, Event{Type: "mouse", Button: ev.Button, X: ev.X, Y: ev.Y})
+		}
+	}
+	return events
+}
+
+// Example of sending a key via robotgo (used for OTG mode).
+func SendKey(code string) {
+	robotgo.KeyTap(code)
+}

--- a/goapp/main.go
+++ b/goapp/main.go
@@ -1,116 +1,64 @@
 package main
 
 import (
-	"fmt"
 	"log"
-	"os"
+
+	"github.com/yourname/scrcpy-go/adb"
+	"github.com/yourname/scrcpy-go/input"
+	"github.com/yourname/scrcpy-go/protocol"
+	"github.com/yourname/scrcpy-go/video"
 )
 
-type Options struct {
-	ShowHelp    bool
-	ShowVersion bool
-	PauseOnExit string // "true", "false", "if_error"
-	LogLevel    string
-	UseOTG      bool
-	V4L2Device  string
-}
-
-const Version = "0.1.0"
-
-func parseArgs(args []string) (*Options, error) {
-	opts := &Options{
-		PauseOnExit: "false",
-		LogLevel:    "info",
-	}
-
-	for _, arg := range args {
-		switch arg {
-		case "--help", "-h":
-			opts.ShowHelp = true
-		case "--version", "-v":
-			opts.ShowVersion = true
-		case "--pause":
-			opts.PauseOnExit = "true"
-		case "--otg":
-			opts.UseOTG = true
-		case "--debug":
-			opts.LogLevel = "debug"
-			// 你可以擴充更多參數
-		}
-	}
-
-	return opts, nil
-}
-
-func mainScrcpy(opts *Options) int {
-	fmt.Printf("scrcpy-go %s <https://github.com/yourname/scrcpy-go>\n", Version)
-
-	if opts.ShowHelp {
-		fmt.Println("Usage: scrcpy-go [options]")
-		// 印出更多說明
-		return 0
-	}
-
-	if opts.ShowVersion {
-		fmt.Println("Version:", Version)
-		return 0
-	}
-
-	// 模擬 net_init()
-	if err := initNetwork(); err != nil {
-		log.Println("Failed to init network:", err)
-		return 1
-	}
-
-	// 模擬 log 設定
-	configureLog(opts.LogLevel)
-
-	// 模擬 USB / TCP 選擇邏輯
-	var exitCode int
-	if opts.UseOTG {
-		exitCode = runOTG(opts)
-	} else {
-		exitCode = runScrcpy(opts)
-	}
-
-	// 模擬 pause on exit
-	if opts.PauseOnExit == "true" || (opts.PauseOnExit == "if_error" && exitCode != 0) {
-		fmt.Println("Press Enter to continue...")
-		fmt.Scanln()
-	}
-
-	return exitCode
-}
+const serverJar = "../server/scrcpy-server.jar"
 
 func main() {
-	opts, err := parseArgs(os.Args[1:])
+	dev, err := adb.NewDevice("")
 	if err != nil {
-		log.Println("Failed to parse args:", err)
-		os.Exit(1)
+		log.Fatal(err)
 	}
 
-	code := mainScrcpy(opts)
-	os.Exit(code)
-}
+	if err := dev.PushServer(serverJar); err != nil {
+		log.Fatal("push server:", err)
+	}
 
-func initNetwork() error {
-	// 預留初始化 socket 等邏輯
-	return nil
-}
+	stream, err := dev.StartServer()
+	if err != nil {
+		log.Fatal("start server:", err)
+	}
+	defer stream.Close()
 
-func configureLog(level string) {
-	log.SetFlags(log.LstdFlags | log.Lshortfile)
-	log.Println("Log level:", level)
-}
+	dec, err := video.NewDecoder()
+	if err != nil {
+		log.Fatal("init decoder:", err)
+	}
 
-func runScrcpy(opts *Options) int {
-	log.Println("Running scrcpy (TCP mode)...")
-	// 預留啟動邏輯
-	return 0
-}
+	disp, err := video.NewDisplay("scrcpy-go", 720, 1280)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer disp.Close()
 
-func runOTG(opts *Options) int {
-	log.Println("Running scrcpy (OTG mode)...")
-	// 預留啟動邏輯
-	return 0
+	for {
+		pkt, err := protocol.Decode(stream)
+		if err != nil {
+			log.Println("read:", err)
+			break
+		}
+		if pkt.Type == 0 { // video packet
+			frame, ok, err := dec.Decode(pkt.Body)
+			if err != nil {
+				log.Println("decode:", err)
+				continue
+			}
+			if ok {
+				videoData := frame.Data()
+				disp.Render(videoData)
+			}
+		}
+		events := input.Capture()
+		_ = events // future: encode/send using protocol encoder
+		if !disp.Poll() {
+			break
+		}
+	}
 }

--- a/goapp/protocol/decoder.go
+++ b/goapp/protocol/decoder.go
@@ -1,0 +1,27 @@
+package protocol
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+// Packet represents a simplified packet header from scrcpy server.
+type Packet struct {
+	Type uint8
+	Size uint32
+	Body []byte
+}
+
+// Decode reads a packet from the given reader.
+func Decode(r io.Reader) (*Packet, error) {
+	var header [5]byte
+	if _, err := io.ReadFull(r, header[:]); err != nil {
+		return nil, err
+	}
+	p := &Packet{Type: header[0], Size: binary.BigEndian.Uint32(header[1:])}
+	p.Body = make([]byte, p.Size)
+	if _, err := io.ReadFull(r, p.Body); err != nil {
+		return nil, err
+	}
+	return p, nil
+}

--- a/goapp/protocol/encoder.go
+++ b/goapp/protocol/encoder.go
@@ -1,0 +1,34 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+// BuildKeyEvent builds a keyboard control message packet.
+func BuildKeyEvent(code uint32, down bool) []byte {
+	buf := new(bytes.Buffer)
+	buf.WriteByte(0) // message type: key event
+	var action uint8
+	if down {
+		action = 1
+	}
+	binary.Write(buf, binary.BigEndian, action)
+	binary.Write(buf, binary.BigEndian, code)
+	return buf.Bytes()
+}
+
+// BuildMouseEvent builds a mouse control message packet.
+func BuildMouseEvent(x, y int32, button uint8, down bool) []byte {
+	buf := new(bytes.Buffer)
+	buf.WriteByte(1) // message type: mouse event
+	binary.Write(buf, binary.BigEndian, button)
+	binary.Write(buf, binary.BigEndian, x)
+	binary.Write(buf, binary.BigEndian, y)
+	var action uint8
+	if down {
+		action = 1
+	}
+	binary.Write(buf, binary.BigEndian, action)
+	return buf.Bytes()
+}

--- a/goapp/video/decoder.go
+++ b/goapp/video/decoder.go
@@ -1,0 +1,52 @@
+package video
+
+import (
+	"fmt"
+	"github.com/giorgisio/goav/avcodec"
+	"github.com/giorgisio/goav/avutil"
+)
+
+// Decoder wraps an FFmpeg H264 decoder.
+type Decoder struct {
+	codecCtx *avcodec.Context
+	parser   *avcodec.ParserContext
+	frame    *avutil.Frame
+}
+
+// NewDecoder initializes the FFmpeg decoder for H.264 stream.
+func NewDecoder() (*Decoder, error) {
+	codec := avcodec.AvcodecFindDecoder(avcodec.AV_CODEC_ID_H264)
+	if codec == nil {
+		return nil, fmt.Errorf("H264 decoder not found")
+	}
+	c := codec.AvcodecAllocContext3()
+	if c.AvcodecOpen2(codec, nil) < 0 {
+		return nil, fmt.Errorf("could not open codec")
+	}
+	parser := avcodec.AvParserInit(int(avcodec.AV_CODEC_ID_H264))
+	if parser == nil {
+		return nil, fmt.Errorf("parser init failed")
+	}
+	return &Decoder{codecCtx: c, parser: parser, frame: avutil.AvFrameAlloc()}, nil
+}
+
+// Decode decodes a packet of H264 data and returns whether a frame is ready.
+func (d *Decoder) Decode(data []byte) (*avutil.Frame, bool, error) {
+	var gotFrame int
+	avPacket := avcodec.AvPacketAlloc()
+	avPacket.AvInitPacket()
+	avPacket.SetData(data)
+	avPacket.SetSize(len(data))
+	ret := avcodec.AvcodecSendPacket(d.codecCtx, avPacket)
+	if ret < 0 {
+		return nil, false, fmt.Errorf("send packet failed")
+	}
+	ret = avcodec.AvcodecReceiveFrame(d.codecCtx, d.frame)
+	if ret == 0 {
+		gotFrame = 1
+	}
+	if gotFrame != 0 {
+		return d.frame, true, nil
+	}
+	return nil, false, nil
+}

--- a/goapp/video/display.go
+++ b/goapp/video/display.go
@@ -1,0 +1,63 @@
+package video
+
+import (
+	"github.com/veandco/go-sdl2/sdl"
+)
+
+// Display uses SDL2 to show frames decoded from the video stream.
+type Display struct {
+	window   *sdl.Window
+	renderer *sdl.Renderer
+	texture  *sdl.Texture
+	width    int
+	height   int
+}
+
+// NewDisplay creates the SDL window and renderer.
+func NewDisplay(title string, w, h int) (*Display, error) {
+	if err := sdl.Init(sdl.INIT_VIDEO); err != nil {
+		return nil, err
+	}
+	win, err := sdl.CreateWindow(title, sdl.WINDOWPOS_UNDEFINED, sdl.WINDOWPOS_UNDEFINED,
+		int32(w), int32(h), sdl.WINDOW_SHOWN)
+	if err != nil {
+		return nil, err
+	}
+	rend, err := sdl.CreateRenderer(win, -1, sdl.RENDERER_ACCELERATED)
+	if err != nil {
+		return nil, err
+	}
+	tex, err := rend.CreateTexture(sdl.PIXELFORMAT_IYUV, sdl.TEXTUREACCESS_STREAMING, int32(w), int32(h))
+	if err != nil {
+		return nil, err
+	}
+	return &Display{window: win, renderer: rend, texture: tex, width: w, height: h}, nil
+}
+
+// Render writes a YUV frame to the texture and updates the screen.
+func (d *Display) Render(yuv []byte) error {
+	d.texture.Update(nil, yuv, d.width)
+	d.renderer.Copy(d.texture, nil, nil)
+	d.renderer.Present()
+	return nil
+}
+
+// Poll handles SDL events to keep the window responsive.
+func (d *Display) Poll() bool {
+	for event := sdl.PollEvent(); event != nil; event = sdl.PollEvent() {
+		switch event.(type) {
+		case *sdl.QuitEvent:
+			return false
+		}
+	}
+	sdl.Delay(10)
+	return true
+}
+
+// Close destroys SDL resources.
+func (d *Display) Close() {
+	d.texture.Destroy()
+	d.renderer.Destroy()
+	d.window.Destroy()
+	sdl.Quit()
+}


### PR DESCRIPTION
## Summary
- add Go module with dependencies for a scrcpy client
- implement adb support for starting the scrcpy server
- add FFmpeg-based video decoder and SDL2 display modules
- add input capture and protocol encode/decode helpers
- provide main application showing how pieces connect

## Testing
- `go vet ./...` *(fails: missing go.sum due to network restrictions)*
- `go test ./...` *(fails: missing go.sum due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688268a82e9883208f267a3641c9a446