### PR TITLE
Add Chinese comments and README to goapp

### DIFF
--- a/goapp/README.md
+++ b/goapp/README.md
@@ -1,0 +1,20 @@
+# scrcpy-go 簡介
+
+這個目錄包含以 Go 撰寫的 scrcpy 客戶端範例，示範如何透過 ADB 啟動
+scrcpy 伺服器並在本機端顯示裝置畫面。
+
+## 需求
+- Go 1.20 以上
+- 已安裝 `adb` 並可與 Android 裝置連線
+- 系統需能安裝 SDL2、FFmpeg 以及 robotgo 相關依賴
+
+## 執行方式
+```bash
+cd goapp
+go run .
+```
+程式會自動推送 `../server/scrcpy-server.jar` 至裝置並啟動伺服器，之後
+會開啟視窗顯示畫面，並於終端輸出錯誤訊息（若有）。
+
+此範例僅提供影片顯示功能，輸入事件捕捉後並未送回裝置，可依需求在
+`input` 與 `protocol` 套件中擴充。

--- a/goapp/adb/device.go
+++ b/goapp/adb/device.go
@@ -1,3 +1,4 @@
+// 封裝對 adb 的操作，協助在裝置上啟動 scrcpy 伺服器
 package adb
 
 import (
@@ -7,14 +8,13 @@ import (
 	"github.com/zach-klippenstein/goadb"
 )
 
-// Device wraps an adb Device and provides helper methods
-// to start the scrcpy server on the Android device.
+// Device 代表一台 Android 裝置
 type Device struct {
-	adb    *adb.Adb
-	device *adb.Device
+	adb    *adb.Adb    // adb 客戶端
+	device *adb.Device // 特定序號的裝置
 }
 
-// NewDevice connects to adb and returns a Device for the given serial.
+// NewDevice 連線至 adb，並回傳指定序號的 Device
 func NewDevice(serial string) (*Device, error) {
 	a, err := adb.NewWithConfig(adb.ServerConfig{PathToAdb: "adb"})
 	if err != nil {
@@ -24,13 +24,13 @@ func NewDevice(serial string) (*Device, error) {
 	return &Device{adb: a, device: d}, nil
 }
 
-// PushServer pushes scrcpy-server.jar to the device temporary directory.
+// PushServer 將 scrcpy-server.jar 推送到裝置的暫存目錄
 func (d *Device) PushServer(localPath string) error {
 	remotePath := "/data/local/tmp/scrcpy-server.jar"
 	return d.device.PushFile(localPath, remotePath)
 }
 
-// StartServer starts the scrcpy server using adb shell.
+// StartServer 透過 adb shell 啟動 scrcpy 伺服器並回傳串流
 func (d *Device) StartServer() (io.ReadCloser, error) {
 	// The server outputs the video stream on stdout, so we use StartShell.
 	// The command is simplified for demonstration purposes.
@@ -38,7 +38,7 @@ func (d *Device) StartServer() (io.ReadCloser, error) {
 	return d.device.RunCommandWithByteOutput(cmd)
 }
 
-// Forward establishes a port forward from local to the scrcpy tunnel.
+// Forward 在本地建立與 scrcpy 通道的連線轉發
 func (d *Device) Forward(local string) error {
 	return d.adb.Forward(local, "localabstract:scrcpy")
 }

--- a/goapp/input/handler.go
+++ b/goapp/input/handler.go
@@ -1,3 +1,4 @@
+// 處理鍵盤與滑鼠輸入事件
 package input
 
 import (
@@ -5,8 +6,7 @@ import (
 	"github.com/veandco/go-sdl2/sdl"
 )
 
-// Event represents a simplified control event that will be encoded
-// and sent to the scrcpy server.
+// Event 描述將來要傳送給 scrcpy 伺服器的控制事件
 type Event struct {
 	Type   string
 	Key    sdl.Keycode
@@ -14,7 +14,7 @@ type Event struct {
 	X, Y   int32
 }
 
-// Capture polls SDL for keyboard/mouse events and converts them to Event.
+// Capture 從 SDL 取得鍵盤與滑鼠事件並轉換成 Event
 func Capture() []Event {
 	var events []Event
 	for e := sdl.PollEvent(); e != nil; e = sdl.PollEvent() {
@@ -30,7 +30,7 @@ func Capture() []Event {
 	return events
 }
 
-// Example of sending a key via robotgo (used for OTG mode).
+// 使用 robotgo 直接在主機端產生按鍵（OTG 模式範例）
 func SendKey(code string) {
 	robotgo.KeyTap(code)
 }

--- a/goapp/main.go
+++ b/goapp/main.go
@@ -1,3 +1,4 @@
+// 這是一個以 Go 撰寫的簡易 scrcpy 客戶端範例
 package main
 
 import (
@@ -9,54 +10,62 @@ import (
 	"github.com/yourname/scrcpy-go/video"
 )
 
+// scrcpy 伺服器的 jar 檔路徑
 const serverJar = "../server/scrcpy-server.jar"
 
 func main() {
+	// 連線到第一台可用的裝置
 	dev, err := adb.NewDevice("")
 	if err != nil {
 		log.Fatal(err)
 	}
 
+	// 將伺服器檔案推送至裝置暫存目錄
 	if err := dev.PushServer(serverJar); err != nil {
 		log.Fatal("push server:", err)
 	}
 
+	// 啟動 scrcpy 伺服器並取得資料串流
 	stream, err := dev.StartServer()
 	if err != nil {
 		log.Fatal("start server:", err)
 	}
 	defer stream.Close()
 
+	// 初始化影片解碼器
 	dec, err := video.NewDecoder()
 	if err != nil {
 		log.Fatal("init decoder:", err)
 	}
 
+	// 建立顯示視窗
 	disp, err := video.NewDisplay("scrcpy-go", 720, 1280)
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer disp.Close()
 
+	// 主迴圈：讀取封包、顯示畫面並處理輸入
 	for {
 		pkt, err := protocol.Decode(stream)
 		if err != nil {
 			log.Println("read:", err)
 			break
 		}
-		if pkt.Type == 0 { // video packet
+		if pkt.Type == 0 { // 視訊封包
 			frame, ok, err := dec.Decode(pkt.Body)
 			if err != nil {
 				log.Println("decode:", err)
 				continue
 			}
-			if ok {
+			if ok { // 取得完整畫面後進行渲染
 				videoData := frame.Data()
 				disp.Render(videoData)
 			}
 		}
+		// 取得鍵盤滑鼠事件（尚未傳送回裝置）
 		events := input.Capture()
-		_ = events // future: encode/send using protocol encoder
+		_ = events // 未來可透過 encoder 發送控制訊息
 		if !disp.Poll() {
 			break
 		}

--- a/goapp/protocol/decoder.go
+++ b/goapp/protocol/decoder.go
@@ -1,3 +1,4 @@
+// 與 scrcpy 伺服器溝通所用的封包格式解析
 package protocol
 
 import (
@@ -5,14 +6,14 @@ import (
 	"io"
 )
 
-// Packet represents a simplified packet header from scrcpy server.
+// Packet 表示從 scrcpy 伺服器收到的簡化封包
 type Packet struct {
 	Type uint8
 	Size uint32
 	Body []byte
 }
 
-// Decode reads a packet from the given reader.
+// Decode 從指定的 reader 讀取並解析封包
 func Decode(r io.Reader) (*Packet, error) {
 	var header [5]byte
 	if _, err := io.ReadFull(r, header[:]); err != nil {

--- a/goapp/protocol/encoder.go
+++ b/goapp/protocol/encoder.go
@@ -1,3 +1,4 @@
+// 建立傳送至 scrcpy 伺服器的控制訊息封包
 package protocol
 
 import (
@@ -5,10 +6,10 @@ import (
 	"encoding/binary"
 )
 
-// BuildKeyEvent builds a keyboard control message packet.
+// BuildKeyEvent 建立鍵盤事件封包
 func BuildKeyEvent(code uint32, down bool) []byte {
 	buf := new(bytes.Buffer)
-	buf.WriteByte(0) // message type: key event
+	buf.WriteByte(0) // 封包類型：鍵盤事件
 	var action uint8
 	if down {
 		action = 1
@@ -18,10 +19,10 @@ func BuildKeyEvent(code uint32, down bool) []byte {
 	return buf.Bytes()
 }
 
-// BuildMouseEvent builds a mouse control message packet.
+// BuildMouseEvent 建立滑鼠事件封包
 func BuildMouseEvent(x, y int32, button uint8, down bool) []byte {
 	buf := new(bytes.Buffer)
-	buf.WriteByte(1) // message type: mouse event
+	buf.WriteByte(1) // 封包類型：滑鼠事件
 	binary.Write(buf, binary.BigEndian, button)
 	binary.Write(buf, binary.BigEndian, x)
 	binary.Write(buf, binary.BigEndian, y)

--- a/goapp/video/decoder.go
+++ b/goapp/video/decoder.go
@@ -1,3 +1,4 @@
+// 利用 FFmpeg 將收到的 H264 資料解碼
 package video
 
 import (
@@ -6,14 +7,14 @@ import (
 	"github.com/giorgisio/goav/avutil"
 )
 
-// Decoder wraps an FFmpeg H264 decoder.
+// Decoder 包裝 FFmpeg 的 H264 解碼器
 type Decoder struct {
-	codecCtx *avcodec.Context
-	parser   *avcodec.ParserContext
-	frame    *avutil.Frame
+	codecCtx *avcodec.Context       // 解碼器上下文
+	parser   *avcodec.ParserContext // 用來解析 H264 串流
+	frame    *avutil.Frame          // 暫存解碼後的影格
 }
 
-// NewDecoder initializes the FFmpeg decoder for H.264 stream.
+// NewDecoder 初始化 H264 解碼器
 func NewDecoder() (*Decoder, error) {
 	codec := avcodec.AvcodecFindDecoder(avcodec.AV_CODEC_ID_H264)
 	if codec == nil {
@@ -30,7 +31,7 @@ func NewDecoder() (*Decoder, error) {
 	return &Decoder{codecCtx: c, parser: parser, frame: avutil.AvFrameAlloc()}, nil
 }
 
-// Decode decodes a packet of H264 data and returns whether a frame is ready.
+// Decode 解碼一個 H264 資料包，若成功取得影格則回傳
 func (d *Decoder) Decode(data []byte) (*avutil.Frame, bool, error) {
 	var gotFrame int
 	avPacket := avcodec.AvPacketAlloc()

--- a/goapp/video/display.go
+++ b/goapp/video/display.go
@@ -1,10 +1,11 @@
+// 利用 SDL2 將解碼後的影像顯示在視窗中
 package video
 
 import (
 	"github.com/veandco/go-sdl2/sdl"
 )
 
-// Display uses SDL2 to show frames decoded from the video stream.
+// Display 使用 SDL2 顯示從影片串流解碼出的影格
 type Display struct {
 	window   *sdl.Window
 	renderer *sdl.Renderer
@@ -13,7 +14,7 @@ type Display struct {
 	height   int
 }
 
-// NewDisplay creates the SDL window and renderer.
+// NewDisplay 建立 SDL 視窗與繪圖器
 func NewDisplay(title string, w, h int) (*Display, error) {
 	if err := sdl.Init(sdl.INIT_VIDEO); err != nil {
 		return nil, err
@@ -34,7 +35,7 @@ func NewDisplay(title string, w, h int) (*Display, error) {
 	return &Display{window: win, renderer: rend, texture: tex, width: w, height: h}, nil
 }
 
-// Render writes a YUV frame to the texture and updates the screen.
+// Render 將 YUV 影格寫入紋理並更新畫面
 func (d *Display) Render(yuv []byte) error {
 	d.texture.Update(nil, yuv, d.width)
 	d.renderer.Copy(d.texture, nil, nil)
@@ -42,7 +43,7 @@ func (d *Display) Render(yuv []byte) error {
 	return nil
 }
 
-// Poll handles SDL events to keep the window responsive.
+// Poll 處理事件以維持視窗運作
 func (d *Display) Poll() bool {
 	for event := sdl.PollEvent(); event != nil; event = sdl.PollEvent() {
 		switch event.(type) {
@@ -54,7 +55,7 @@ func (d *Display) Poll() bool {
 	return true
 }
 
-// Close destroys SDL resources.
+// Close 釋放 SDL 資源
 func (d *Display) Close() {
 	d.texture.Destroy()
 	d.renderer.Destroy()


### PR DESCRIPTION
## Summary
- add Chinese comments for Go example files under `goapp`
- document usage in `goapp/README.md`

## Testing
- `gofmt -w goapp/main.go goapp/adb/device.go goapp/input/handler.go goapp/protocol/decoder.go goapp/protocol/encoder.go goapp/video/decoder.go goapp/video/display.go`
- ⚠️ `go mod tidy` failed: `Forbidden` (no internet access)


------
https://chatgpt.com/codex/tasks/task_e_68826a043c588320af8ce4ad3d5aad5d