### PR TITLE
Remove goadb from goapp

### DIFF
--- a/goapp/adb/device.go
+++ b/goapp/adb/device.go
@@ -2,50 +2,84 @@
 package adb
 
 import (
-        "fmt"
-        "io"
-        "os/exec"
-
-        "github.com/zach-klippenstein/goadb"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
 )
 
 // Device 代表一台 Android 裝置
 type Device struct {
-	adb    *adb.Adb    // adb 客戶端
-	device *adb.Device // 特定序號的裝置
+	serial string
+}
+
+type cmdReadCloser struct {
+	io.ReadCloser
+	cmd *exec.Cmd
+}
+
+func (c *cmdReadCloser) Close() error {
+	err1 := c.ReadCloser.Close()
+	err2 := c.cmd.Wait()
+	if err1 != nil {
+		return err1
+	}
+	return err2
 }
 
 // NewDevice 連線至 adb，並回傳指定序號的 Device
 func NewDevice(serial string) (*Device, error) {
-	a, err := adb.NewWithConfig(adb.ServerConfig{PathToAdb: "adb"})
-	if err != nil {
-		return nil, fmt.Errorf("create adb client: %w", err)
+	cmd := exec.Command("adb", "start-server")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("start adb server: %w (%s)", err, string(out))
 	}
-	d := a.Device(adb.DeviceWithSerial(serial))
-	return &Device{adb: a, device: d}, nil
+	return &Device{serial: serial}, nil
 }
 
 // PushServer 將 scrcpy-server.jar 推送到裝置的暫存目錄
 func (d *Device) PushServer(localPath string) error {
-        remotePath := "/data/local/tmp/scrcpy-server.jar"
-        // goadb.Device does not provide a PushFile helper in the current
-        // dependency version, so fallback to invoking `adb push` directly.
-        cmd := exec.Command("adb", "push", localPath, remotePath)
-        if out, err := cmd.CombinedOutput(); err != nil {
-                return fmt.Errorf("push server: %w (%s)", err, string(out))
-        }
-        return nil
+	remotePath := "/data/local/tmp/scrcpy-server.jar"
+	args := []string{}
+	if d.serial != "" {
+		args = append(args, "-s", d.serial)
+	}
+	args = append(args, "push", localPath, remotePath)
+	cmd := exec.Command("adb", args...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("push server: %w (%s)", err, string(out))
+	}
+	return nil
 }
 
 // StartServer 透過 adb shell 啟動 scrcpy 伺服器並回傳串流
 func (d *Device) StartServer() (io.ReadCloser, error) {
-	// The server outputs the video stream on stdout, so we use StartShell.
-	// The command is simplified for demonstration purposes.
-	cmd := "CLASSPATH=/data/local/tmp/scrcpy-server.jar app_process / com.genymobile.scrcpy.Server 1.25"
-	return d.device.RunCommandWithByteOutput(cmd)
+	args := []string{}
+	if d.serial != "" {
+		args = append(args, "-s", d.serial)
+	}
+	args = append(args, "shell", "CLASSPATH=/data/local/tmp/scrcpy-server.jar", "app_process", "/", "com.genymobile.scrcpy.Server", "1.25")
+	cmd := exec.Command("adb", args...)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("start server pipe: %w", err)
+	}
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start server: %w", err)
+	}
+	return &cmdReadCloser{ReadCloser: stdout, cmd: cmd}, nil
 }
 
 // Forward 在本地建立與 scrcpy 通道的連線轉發
 func (d *Device) Forward(local string) error {
-	return d.adb.Forward(local, "localabstract:scrcpy")
+	args := []string{}
+	if d.serial != "" {
+		args = append(args, "-s", d.serial)
+	}
+	args = append(args, "forward", local, "localabstract:scrcpy")
+	cmd := exec.Command("adb", args...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("forward: %w (%s)", err, string(out))
+	}
+	return nil
 }

--- a/goapp/go.mod
+++ b/goapp/go.mod
@@ -5,10 +5,9 @@ go 1.23.0
 toolchain go1.23.2
 
 require (
-	github.com/giorgisio/goav v0.1.0
-	github.com/go-vgo/robotgo v0.110.8
-	github.com/veandco/go-sdl2 v0.4.12
-	github.com/zach-klippenstein/goadb v0.0.0-20201208042340-620e0e950ed7
+        github.com/giorgisio/goav v0.1.0
+        github.com/go-vgo/robotgo v0.110.8
+        github.com/veandco/go-sdl2 v0.4.12
 )
 
 require (

--- a/goapp/go.sum
+++ b/goapp/go.sum
@@ -66,8 +66,6 @@ github.com/veandco/go-sdl2 v0.4.12 h1:zY/yQAR+fWmLquiOSjDaOV9GjRHaFtFwnFjLSIIzL3
 github.com/veandco/go-sdl2 v0.4.12/go.mod h1:OROqMhHD43nT4/i9crJukyVecjPNYYuCofep6SNiAjY=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-github.com/zach-klippenstein/goadb v0.0.0-20201208042340-620e0e950ed7 h1:xwmuUst0P21SJmJlIOPPq/geECy23t+DUxgnRSqt6Hg=
-github.com/zach-klippenstein/goadb v0.0.0-20201208042340-620e0e950ed7/go.mod h1:Drd+klC4FSDx0vKNEQDsSpWX5so04NA7l0vzHqkH8AQ=
 golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6 h1:y5zboxd6LQAqYIhHnB48p0ByQ/GnQx2BE33L8BOHQkI=
 golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6/go.mod h1:U6Lno4MTRCDY+Ba7aCcauB9T60gsv5s4ralQzP72ZoQ=
 golang.org/x/image v0.27.0 h1:C8gA4oWU/tKkdCfYT6T2u4faJu3MeNS5O8UPWlPF61w=


### PR DESCRIPTION
## Summary
- drop the goadb library from the Go example
- call the adb binary directly

## Testing
- `go build ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6883db8e379c8320ab5524c1258e89cd