### PR TITLE
Add adb reverse in Go example

### DIFF
--- a/goapp/README.md
+++ b/goapp/README.md
@@ -13,8 +13,9 @@ scrcpy 伺服器並在本機端顯示裝置畫面。
 cd goapp
 go run .
 ```
-程式會自動推送 `../server/scrcpy-server.jar` 至裝置並啟動伺服器，之後
-會開啟視窗顯示畫面，並於終端輸出錯誤訊息（若有）。
+程式會自動推送 `../server/scrcpy-server.jar` 至裝置並透過 `adb reverse`
+將裝置的 `localabstract:scrcpy` 轉發至本機 `tcp:27183`，接著啟動伺服器，
+之後會開啟視窗顯示畫面，並於終端輸出錯誤訊息（若有）。
 
 此範例僅提供影片顯示功能，輸入事件捕捉後並未送回裝置，可依需求在
 `input` 與 `protocol` 套件中擴充。

--- a/goapp/adb/device.go
+++ b/goapp/adb/device.go
@@ -83,3 +83,17 @@ func (d *Device) Forward(local string) error {
 	}
 	return nil
 }
+
+// Reverse 在裝置端建立連線，使其回連至本機指定的埠號
+func (d *Device) Reverse(remote, local string) error {
+	args := []string{}
+	if d.serial != "" {
+		args = append(args, "-s", d.serial)
+	}
+	args = append(args, "reverse", remote, local)
+	cmd := exec.Command("adb", args...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("reverse: %w (%s)", err, string(out))
+	}
+	return nil
+}

--- a/goapp/main.go
+++ b/goapp/main.go
@@ -17,6 +17,11 @@ func main() {
 		log.Fatal(err)
 	}
 
+	// 透過 adb reverse 將裝置連線轉回本機，便於伺服器傳送資料
+	if err := dev.Reverse("localabstract:scrcpy", "tcp:27183"); err != nil {
+		log.Fatal("reverse:", err)
+	}
+
 	// 將伺服器檔案推送至裝置暫存目錄
 	if err := dev.PushServer(serverJar); err != nil {
 		log.Fatal("push server:", err)


### PR DESCRIPTION
## Summary
- support `adb reverse` in the Go client
- invoke the reverse mapping when starting the server
- document reverse forwarding in the Go example README

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_6883e917c3e88320a2d273a6ae4a675d