### PR TITLE
Add WebRTC streaming example

### DIFF
--- a/goapp/README.md
+++ b/goapp/README.md
@@ -14,8 +14,9 @@ cd goapp
 go run .
 ```
 程式會自動推送 `../server/scrcpy-server.jar` 至裝置並透過 `adb reverse`
-將裝置的 `localabstract:scrcpy` 轉發至本機 `tcp:27183`，接著啟動伺服器，
-之後會開啟視窗顯示畫面，並於終端輸出錯誤訊息（若有）。
+將裝置的 `localabstract:scrcpy` 轉發至本機 `tcp:27183`，接著啟動伺服器。
+修改後的範例會啟動一個 WebRTC 伺服器，從 <http://localhost:8080>
+存取即可在瀏覽器中看到畫面。
 
 此範例僅提供影片顯示功能，輸入事件捕捉後並未送回裝置，可依需求在
 `input` 與 `protocol` 套件中擴充。

--- a/goapp/go.mod
+++ b/goapp/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/lufia/plan9stats v0.0.0-20250317134145-8bc96cf8fc35 // indirect
 	github.com/otiai10/gosseract v2.2.1+incompatible // indirect
 	github.com/otiai10/mint v1.6.3 // indirect
+	github.com/pion/webrtc/v4 v4.0.0
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/robotn/xgb v0.10.0 // indirect
 	github.com/robotn/xgbutil v0.10.0 // indirect

--- a/goapp/main.go
+++ b/goapp/main.go
@@ -2,9 +2,16 @@
 package main
 
 import (
+	"encoding/json"
 	"log"
+	"net/http"
+	"time"
+
+	"github.com/pion/webrtc/v4"
+	"github.com/pion/webrtc/v4/pkg/media"
 
 	"github.com/yourname/scrcpy-go/adb"
+	"github.com/yourname/scrcpy-go/protocol"
 )
 
 // scrcpy 伺服器檔案的路徑
@@ -34,42 +41,69 @@ func main() {
 	}
 	defer stream.Close()
 
-	// // 初始化影片解碼器
-	// dec, err := video.NewDecoder()
-	// if err != nil {
-	// 	log.Fatal("init decoder:", err)
-	// }
+	// 建立 HTTP 伺服器，透過 WebRTC 將影片串流給瀏覽器
+	http.HandleFunc("/offer", func(w http.ResponseWriter, r *http.Request) {
+		var offer webrtc.SessionDescription
+		if err := json.NewDecoder(r.Body).Decode(&offer); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 
-	// // 建立顯示視窗
-	// disp, err := video.NewDisplay("scrcpy-go", 720, 1280)
-	// if err != nil {
-	// 	log.Fatal(err)
-	// }
-	// defer disp.Close()
+		m := &webrtc.MediaEngine{}
+		m.RegisterDefaultCodecs()
+		api := webrtc.NewAPI(webrtc.WithMediaEngine(m))
 
-	// // 主迴圈：讀取封包、顯示畫面並處理輸入
-	// for {
-	// 	pkt, err := protocol.Decode(stream)
-	// 	if err != nil {
-	// 		log.Println("read:", err)
-	// 		break
-	// 	}
-	// 	if pkt.Type == 0 { // 視訊封包
-	// 		frame, ok, err := dec.Decode(pkt.Body)
-	// 		if err != nil {
-	// 			log.Println("decode:", err)
-	// 			continue
-	// 		}
-	// 		if ok { // 取得完整畫面後進行渲染
-	// 			videoData := frame.Data()
-	// 			disp.Render(videoData)
-	// 		}
-	// 	}
-	// 	// 取得鍵盤滑鼠事件（尚未傳送回裝置）
-	// 	events := input.Capture()
-	// 	_ = events // 未來可透過 encoder 發送控制訊息
-	// 	if !disp.Poll() {
-	// 		break
-	// 	}
-	// }
+		pc, err := api.NewPeerConnection(webrtc.Configuration{})
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		track, err := webrtc.NewTrackLocalStaticSample(
+			webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypeH264},
+			"video", "scrcpy")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if _, err := pc.AddTrack(track); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		if err := pc.SetRemoteDescription(offer); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		answer, err := pc.CreateAnswer(nil)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if err := pc.SetLocalDescription(answer); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		<-webrtc.GatheringCompletePromise(pc)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(pc.LocalDescription())
+
+		go func() {
+			for {
+				pkt, err := protocol.Decode(stream)
+				if err != nil {
+					log.Println("stream read:", err)
+					return
+				}
+				if pkt.Type == 0 {
+					track.WriteSample(media.Sample{Data: pkt.Body, Duration: time.Second / 60})
+				}
+			}
+		}()
+	})
+
+	fs := http.FileServer(http.Dir("./web"))
+	http.Handle("/", fs)
+	log.Println("open http://localhost:8080 to view stream")
+	log.Fatal(http.ListenAndServe(":8080", nil))
 }

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>scrcpy WebRTC</title>
+</head>
+<body>
+<video id="v" autoplay playsinline controls></video>
+<script>
+const pc = new RTCPeerConnection();
+pc.ontrack = ev => {
+    document.getElementById('v').srcObject = ev.streams[0];
+};
+pc.addTransceiver('video', {direction:'recvonly'});
+async function start(){
+    const offer = await pc.createOffer();
+    await pc.setLocalDescription(offer);
+    const res = await fetch('/offer', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(pc.localDescription)
+    });
+    const answer = await res.json();
+    await pc.setRemoteDescription(answer);
+}
+start();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add basic WebRTC server example to `goapp/main.go`
- require pion/webrtc in go.mod
- document how to access the stream via a browser
- add `web/index.html` helper page

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*
- `go test ./...` *(fails: directory prefix . does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_6886773d08c88320a262e58cc193a17c