### PR TITLE
Add WebRTC streaming example

### DIFF
--- a/goapp/README.md
+++ b/goapp/README.md
@@ -13,9 +13,10 @@ scrcpy 伺服器並在本機端顯示裝置畫面。
 cd goapp
 go run .
 ```
-程式會自動推送 `../server/scrcpy-server.jar` 至裝置並透過 `adb reverse`
-將裝置的 `localabstract:scrcpy` 轉發至本機 `tcp:27183`，接著啟動伺服器，
-之後會開啟視窗顯示畫面，並於終端輸出錯誤訊息（若有）。
+程式會自動推送 `./assets/scrcpy-server` 至裝置並透過 `adb reverse`
+將裝置的 `localabstract:scrcpy` 轉發至本機 `tcp:27183`，接著啟動伺服器。
+修改後的範例會啟動一個 WebRTC 伺服器，從 <http://localhost:8080>
+存取即可在瀏覽器中看到畫面。
 
 此範例僅提供影片顯示功能，輸入事件捕捉後並未送回裝置，可依需求在
 `input` 與 `protocol` 套件中擴充。

--- a/goapp/go.mod
+++ b/goapp/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/lufia/plan9stats v0.0.0-20250317134145-8bc96cf8fc35 // indirect
 	github.com/otiai10/gosseract v2.2.1+incompatible // indirect
 	github.com/otiai10/mint v1.6.3 // indirect
+	github.com/pion/webrtc/v4 v4.0.0
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/robotn/xgb v0.10.0 // indirect
 	github.com/robotn/xgbutil v0.10.0 // indirect

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>scrcpy WebRTC</title>
+</head>
+<body>
+<video id="v" autoplay playsinline controls></video>
+<script>
+const pc = new RTCPeerConnection();
+pc.ontrack = ev => {
+    document.getElementById('v').srcObject = ev.streams[0];
+};
+pc.addTransceiver('video', {direction:'recvonly'});
+async function start(){
+    const offer = await pc.createOffer();
+    await pc.setLocalDescription(offer);
+    const res = await fetch('/offer', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(pc.localDescription)
+    });
+    const answer = await res.json();
+    await pc.setRemoteDescription(answer);
+}
+start();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add basic WebRTC server example to `goapp/main.go`
- require pion/webrtc in go.mod
- document how to access the stream via a browser
- add `web/index.html` helper page
- handle EOF gracefully during streaming

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*
- `go test ./...` *(fails: directory prefix . does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_6886773d08c88320a262e58cc193a17c