### PR TITLE
Feed Android video into WebRTC

### DIFF
--- a/goapp/main.go
+++ b/goapp/main.go
@@ -4,7 +4,7 @@ package main
 import (
 	"bytes"
 	"encoding/binary"
-        "fmt"
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -109,7 +109,7 @@ func main() {
 		if isConfig {
 			// store SPS/PPS to prepend to next keyframe
 			conf = append(conf[:0], annexb...)
-                        setProfileLevelID(extractProfileLevelID(annexb))
+			setProfileLevelID(extractProfileLevelID(annexb))
 			continue
 		}
 		if isKey && len(conf) > 0 {
@@ -121,7 +121,7 @@ func main() {
 			duration = time.Duration(pts-prevPTS) * time.Microsecond
 		}
 		prevPTS = pts
-		frameCh <- Frame{Data: annexb, Duration: duration}
+		frameCh <- Frame{Data: annexb, Duration: duration, Key: isKey}
 
 		frameCount++
 		totalBytes += int64(frameSize)
@@ -158,24 +158,24 @@ func avccToAnnexB(data []byte) []byte {
 
 // extractProfileLevelID returns profile-level-id from SPS NAL in Annex-B data.
 func extractProfileLevelID(conf []byte) string {
-        const def = "42e01f"
-        start := []byte{0x00, 0x00, 0x00, 0x01}
-        for i := 0; i+4 < len(conf); {
-                if bytes.Equal(conf[i:i+4], start) {
-                        i += 4
-                        if i >= len(conf) {
-                                break
-                        }
-                        nalType := conf[i] & 0x1F
-                        if nalType == 7 && i+4 <= len(conf) {
-                                return fmt.Sprintf("%02x%02x%02x", conf[i+1], conf[i+2], conf[i+3])
-                        }
-                        for i+4 < len(conf) && !bytes.Equal(conf[i:i+4], start) {
-                                i++
-                        }
-                } else {
-                        i++
-                }
-        }
-        return def
+	const def = "42e01f"
+	start := []byte{0x00, 0x00, 0x00, 0x01}
+	for i := 0; i+4 < len(conf); {
+		if bytes.Equal(conf[i:i+4], start) {
+			i += 4
+			if i >= len(conf) {
+				break
+			}
+			nalType := conf[i] & 0x1F
+			if nalType == 7 && i+4 <= len(conf) {
+				return fmt.Sprintf("%02x%02x%02x", conf[i+1], conf[i+2], conf[i+3])
+			}
+			for i+4 < len(conf) && !bytes.Equal(conf[i:i+4], start) {
+				i++
+			}
+		} else {
+			i++
+		}
+	}
+	return def
 }


### PR DESCRIPTION
## Summary
- forward H.264 frames from scrcpy to a shared channel
- stream those frames to the WebRTC track instead of a generated ffmpeg source

## Testing
- `go build`
- `go vet`


------
https://chatgpt.com/codex/tasks/task_e_68a219dfcc048320b6962fa3d4bd77dd